### PR TITLE
feat:nanotime

### DIFF
--- a/middleware/logging/logging.go
+++ b/middleware/logging/logging.go
@@ -1,13 +1,12 @@
 package logging
 
 import (
-	"net/http"
-	"strings"
-	"time"
-
 	config "github.com/go-kratos/gateway/api/gateway/config/v1"
 	"github.com/go-kratos/gateway/middleware"
+	"github.com/go-kratos/gateway/nanotime"
 	"github.com/go-kratos/kratos/v2/log"
+	"net/http"
+	"strings"
 )
 
 func init() {
@@ -18,7 +17,7 @@ func init() {
 func Middleware(c *config.Middleware) (middleware.Middleware, error) {
 	return func(next http.RoundTripper) http.RoundTripper {
 		return middleware.RoundTripperFunc(func(req *http.Request) (reply *http.Response, err error) {
-			startTime := time.Now()
+			startTime := nanotime.RuntimeNanotime()
 			reply, err = next.RoundTrip(req)
 			level := log.LevelInfo
 			code := http.StatusBadGateway
@@ -40,7 +39,7 @@ func Middleware(c *config.Middleware) (middleware.Middleware, error) {
 				"query", req.URL.RawQuery,
 				"code", code,
 				"error", errMsg,
-				"latency", time.Since(startTime).Seconds(),
+				"latency", nanotime.SinceSeconds(startTime),
 				"backend", strings.Join(nodes, ","),
 			)
 			return reply, err

--- a/nanotime/nacotime.go
+++ b/nanotime/nacotime.go
@@ -1,0 +1,17 @@
+package nanotime
+
+import (
+	"time"
+	_ "unsafe"
+)
+
+//go:linkname RuntimeNanotime runtime.nanotime
+func RuntimeNanotime() int64
+
+func SinceSeconds(t int64) float64 {
+	return Since(t, time.Second)
+}
+
+func Since(t int64, unit time.Duration) float64 {
+	return float64(RuntimeNanotime()-t) / float64(unit)
+}

--- a/nanotime/nacotime_test.go
+++ b/nanotime/nacotime_test.go
@@ -1,0 +1,28 @@
+package nanotime
+
+import (
+	"testing"
+	"time"
+)
+
+func BenchmarkTimeNow(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		cost := time.Now()
+		time.Since(cost).Seconds()
+	}
+}
+
+func BenchmarkRuntimeNanotime(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		cost := RuntimeNanotime()
+		_ = SinceSeconds(cost)
+	}
+}
+
+func TestProxy_Time(t *testing.T) {
+	n1 := time.Now()
+	n2 := RuntimeNanotime()
+	time.Sleep(time.Second)
+	t.Log(time.Since(n1).Seconds())
+	t.Log(SinceSeconds(n2))
+}


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/go-kratos/gateway/nanotime
BenchmarkTimeNow
BenchmarkTimeNow-10            	16510741	        71.73 ns/op
BenchmarkRuntimeNanotime
BenchmarkRuntimeNanotime-10    	32881779	        37.22 ns/op
```

```
goos: linux
goarch: amd64
pkg: aqgs/gateway/internal/proxy
cpu: Intel(R) Xeon(R) Platinum 8369B CPU @ 2.70GHz
BenchmarkTimeNow-4              16721013                68.36 ns/op
BenchmarkRuntimeNanotime-4      24591564                46.54 ns/op
PASS
```
