### PR TITLE
remove-example-logger-middleware-config

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,7 +6,6 @@ import (
 
 	configv1 "github.com/go-kratos/gateway/api/gateway/config/v1"
 	corsv1 "github.com/go-kratos/gateway/api/gateway/middleware/cors/v1"
-	loggingv1 "github.com/go-kratos/gateway/api/gateway/middleware/logging/v1"
 	tracingv1 "github.com/go-kratos/gateway/api/gateway/middleware/tracing/v1"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -69,10 +68,6 @@ func equalTo() *configv1.Gateway {
 				Options: asAny(&tracingv1.Tracing{
 					HttpEndpoint: "localhost:4318",
 				}),
-			},
-			{
-				Name:    "logging",
-				Options: asAny(&loggingv1.Logging{}),
 			},
 		},
 	}

--- a/config/fixtures/config.yaml
+++ b/config/fixtures/config.yaml
@@ -14,13 +14,10 @@ middlewares:
         - GET
         - POST
         - OPTIONS
-  - name: tracing 
+  - name: tracing
     options:
       '@type': type.googleapis.com/gateway.middleware.tracing.v1.Tracing
       httpEndpoint: 'localhost:4318' # default opentelemetry collector port
-  - name: logging
-    options:
-      '@type': type.googleapis.com/gateway.middleware.logging.v1.Logging
 endpoints:
   - path: /helloworld/*
     protocol: HTTP


### PR DESCRIPTION
logger无需增加在配置文件中

复现步骤

> git clone https://github.com/go-kratos/gateway
> docker build . 
>  docker run  -v /Users/xxxx/open-source/21400-go-kratos-getway/config/fixtures/config.yaml:/data/conf abbfcde33b27

INFO msg=register debug: /debug/watcher
2022/08/17 01:40:53 maxprocs: Leaving GOMAXPROCS=8: CPU quota undefined
INFO msg=the initial config file sha256: 78fc3b65527b9f3bbf7c946a921ec356755f53c89c5cd43ef6be9b2575f41f5e
INFO msg=loading config file: /data/conf
INFO msg=start watch config file
FATAL msg=failed to load config: proto: (line 1:777): unable to resolve "type.googleapis.com/gateway.middleware.logging.v1.Logging": "not found"