### PR TITLE
修复 tracing 中间件未传递 trace_id 到 endpoint 问题

### DIFF
--- a/middleware/tracing/tracing.go
+++ b/middleware/tracing/tracing.go
@@ -72,6 +72,9 @@ func Middleware(c *config.Middleware) (middleware.Middleware, error) {
 				semconv.NetPeerIPKey.String(req.RemoteAddr),
 			)
 
+			car := propagation.HeaderCarrier(req.Header)
+			otel.GetTextMapPropagator().Inject(ctx, car)
+
 			defer func() {
 				if err != nil {
 					span.RecordError(err)


### PR DESCRIPTION
fix #168 
-----
修复前
启动 go-kratos/gateway/cmd/gateway
gateway localhost:8080 
启动 go-kratos/kratos/examples/helloworld/server
修改 main.go ，增加 tracing 中间件及 logging 日志内容
```go
	httpSrv := http.NewServer(
		http.Address(":8000"),
		http.Middleware(
			recovery.Recovery(),
			tracing.Server(),
			logging.Server(logger),
		)
```
```
# gateway logging 
INFO trace_id=da26d8b2c773b472fd98add7f300ea9e span_id=755468d58201f5ec source=accesslog host=127.0.0.1:8080 method=GET scheme=http path=/helloworld/a query= code=200 error= latency=0.000508167 backend=127.0.0.1:8000 backend_code=[200] backend_latency=[0.000498333] last_attempt=true
```
```
# helloworld logging
INFO trace_id=6afd990730325258f1560b61ed03cff9 span_id=e878e83826f06563 kind=server component=http operation=/helloworld.Greeter/SayHello args=name:"a" code=0 reason= stack= latency=1.8833e-05
```
----
修复后
```
# gateway logging 
INFO trace_id=589acc1e6a3b3a850a63e600d0c21be7 span_id=829a1f1ad1e443dc source=accesslog host=127.0.0.1:8080 method=GET scheme=http path=/helloworld/a query= code=200 error= latency=0.001320875 backend=127.0.0.1:8000 backend_code=[200] backend_latency=[0.001309333] last_attempt=true
```
```
# helloworld logging
INFO trace_id=589acc1e6a3b3a850a63e600d0c21be7 span_id=d4abe2cd6e925208 kind=server component=http operation=/helloworld.Greeter/SayHello args=name:"a" code=0 reason= stack= latency=2.0209e-05
```