### PR TITLE
fix: replace strings.TrimLeft with strings.TrimPrefix

### DIFF
--- a/middleware/transcoder/transcoder.go
+++ b/middleware/transcoder/transcoder.go
@@ -57,7 +57,7 @@ func Middleware(c *config.Middleware) (middleware.Middleware, error) {
 			// content-type:
 			// - application/grpc+json
 			// - application/grpc+proto
-			req.Header.Set("Content-Type", "application/grpc+"+strings.TrimLeft(contentType, "application/"))
+			req.Header.Set("Content-Type", "application/grpc+"+strings.TrimPrefix(contentType, "application/"))
 			req.Header.Del("Content-Length")
 			req.ContentLength = int64(len(bb))
 			req.Body = io.NopCloser(bytes.NewReader(bb))


### PR DESCRIPTION
[strings.TrimLeft](https://pkg.go.dev/strings#TrimLeft): TrimLeft returns a slice of the string s with all leading Unicode code points contained in cutset removed.
To remove a prefix, use [TrimPrefix] instead.

example:
```
s := "hello, world!"
s1 := strings.TrimLeft(s, "olhe,") // s1 = " world!"
s2 := strings.TrimPrefix(s, "hello,") // s2 = " world!"
```
in the [original code](https://github.com/go-kratos/gateway/blob/c7f447694a3683ba2d814db06c6f49c6e2802b26/middleware/transcoder/transcoder.go#L60), both of them work fine, but the intention of the original code is clearly to remove a prefix rather than all leading Unicode code points contained in cutset, using `strings.TrimPrefix` clarifies the writer's intention and adheres to the standard library's recommendation.