### PR TITLE
优化耗时监控buckets区间

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -40,7 +40,7 @@ var (
 		Subsystem: "gateway",
 		Name:      "requests_duration_seconds",
 		Help:      "Requests duration(sec).",
-		Buckets:   []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.250, 0.5, 1},
+		Buckets:   []float64{0.2, 0.5, 1, 5},
 	}, []string{"protocol", "method", "path", "service", "basePath"})
 	_metricSentBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "go",


### PR DESCRIPTION
关注耗时200ms 500ms 1s 5s 区间。
不再关注2ms 25ms等无意义区间的值