### PR TITLE
add exact router pre-router

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -58,12 +58,19 @@ func WithAttemptTimeoutContext(f AttemptTimeoutContext) Option {
 	}
 }
 
+func WithRouterOptions(opts ...mux.Option) Option {
+	return func(p *Proxy) {
+		p.routerOptions = opts
+	}
+}
+
 // AttemptTimeoutContext is a function type that prepares a context with timeout for an HTTP request.
 type AttemptTimeoutContext func(ctx context.Context, req *http.Request, timeout time.Duration) (context.Context, context.CancelFunc)
 
 // Proxy is a gateway proxy.
 type Proxy struct {
 	router                       atomic.Value
+	routerOptions                []mux.Option
 	clientFactory                client.Factory
 	middlewareFactory            middleware.FactoryV2
 	observable                   Observable
@@ -88,7 +95,11 @@ func New(clientFactory client.Factory, middlewareFactory middleware.FactoryV2, o
 	if p.observable == nil {
 		p.observable = NewObservable()
 	}
-	p.router.Store(mux.NewRouter(p.notFoundHandler, p.methodNotAllowedHandler))
+	p.router.Store(mux.NewRouter(
+		p.notFoundHandler,
+		p.methodNotAllowedHandler,
+		p.routerOptions...,
+	))
 	return p, nil
 }
 
@@ -299,7 +310,11 @@ func (p *Proxy) buildEndpoint(buildCtx *client.BuildContext, e *config.Endpoint,
 
 // Update updates service endpoint.
 func (p *Proxy) Update(buildContext *client.BuildContext, c *config.Gateway) (retError error) {
-	router := mux.NewRouter(http.HandlerFunc(notFoundHandler), http.HandlerFunc(methodNotAllowedHandler))
+	router := mux.NewRouter(
+		http.HandlerFunc(notFoundHandler),
+		http.HandlerFunc(methodNotAllowedHandler),
+		p.routerOptions...,
+	)
 	for _, e := range c.Endpoints {
 		handler, closer, err := p.buildEndpoint(buildContext, e, c.Middlewares)
 		if err != nil {

--- a/router/mux/mux.go
+++ b/router/mux/mux.go
@@ -44,9 +44,9 @@ type muxRouter struct {
 type Option func(*muxRouter)
 
 // WithPreRouter sets the pre-router for mux router.
-func WithPreRouter(newPre func() PreRouter) Option {
+func WithPreRouter(pre PreRouter) Option {
 	return func(m *muxRouter) {
-		m.pre = newPre()
+		m.pre = pre
 	}
 }
 

--- a/router/mux/mux.go
+++ b/router/mux/mux.go
@@ -43,18 +43,10 @@ type muxRouter struct {
 // Option is mux router option.
 type Option func(*muxRouter)
 
-type preRouterCloner interface {
-	clonePreRouter() PreRouter
-}
-
 // WithPreRouter sets the pre-router for mux router.
-func WithPreRouter(r PreRouter) Option {
+func WithPreRouter(newPre func() PreRouter) Option {
 	return func(m *muxRouter) {
-		if cloner, ok := r.(preRouterCloner); ok {
-			m.pre = cloner.clonePreRouter()
-			return
-		}
-		m.pre = r
+		m.pre = newPre()
 	}
 }
 

--- a/router/mux/mux.go
+++ b/router/mux/mux.go
@@ -2,6 +2,7 @@ package mux
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"os"
@@ -33,8 +34,20 @@ var _ = new(router.Router)
 
 type muxRouter struct {
 	*mux.Router
+	pre PreRouter
+
 	wg        *sync.WaitGroup
 	allCloser []io.Closer
+}
+
+// Option is mux router option.
+type Option func(*muxRouter)
+
+// WithPreRouter sets the pre-router for mux router.
+func WithPreRouter(r PreRouter) Option {
+	return func(m *muxRouter) {
+		m.pre = r
+	}
 }
 
 func ProtectedHandler(h http.Handler) http.Handler {
@@ -48,10 +61,14 @@ func ProtectedHandler(h http.Handler) http.Handler {
 }
 
 // NewRouter new a mux router.
-func NewRouter(notFoundHandler, methodNotAllowedHandler http.Handler) router.Router {
+func NewRouter(notFoundHandler, methodNotAllowedHandler http.Handler, opts ...Option) router.Router {
 	r := &muxRouter{
 		Router: mux.NewRouter().StrictSlash(EnableStrictSlash),
+		pre:    NewNopRouter(),
 		wg:     &sync.WaitGroup{},
+	}
+	for _, opt := range opts {
+		opt(r)
 	}
 	r.Router.Handle("/metrics", ProtectedHandler(promhttp.Handler()))
 	r.Router.NotFoundHandler = notFoundHandler
@@ -80,6 +97,10 @@ func (r *muxRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	r.wg.Add(1)
 	defer r.wg.Done()
 	req.URL.Path = cleanPath(req.URL.Path)
+	if handler, ok := r.pre.Match(req); ok {
+		handler.ServeHTTP(w, req)
+		return
+	}
 	r.Router.ServeHTTP(w, req)
 }
 
@@ -103,6 +124,7 @@ func (r *muxRouter) Handle(pattern, method, host string, handler http.Handler, c
 	if err := next.GetError(); err != nil {
 		return err
 	}
+	r.pre.Register(next, handler)
 	r.allCloser = append(r.allCloser, closer)
 	return nil
 }
@@ -142,19 +164,27 @@ type RouterInspect struct {
 	Methods          []string `json:"methods"`
 }
 
-func InspectMuxRouter(in interface{}) []*RouterInspect {
+type InspectResponse struct {
+	Routers    []*RouterInspect `json:"routers"`
+	PreRouters json.RawMessage  `json:"pre_routers"`
+}
+
+func InspectMuxRouter(in interface{}) *InspectResponse {
 	r, ok := in.(*muxRouter)
 	if !ok {
 		return nil
 	}
-	var out []*RouterInspect
+	out := &InspectResponse{
+		Routers:    []*RouterInspect{},
+		PreRouters: r.pre.Inspect(),
+	}
 	_ = r.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
 		pathTemplate, _ := route.GetPathTemplate()
 		pathRegexp, _ := route.GetPathRegexp()
 		queriesTemplates, _ := route.GetQueriesTemplates()
 		queriesRegexps, _ := route.GetQueriesRegexp()
 		methods, _ := route.GetMethods()
-		out = append(out, &RouterInspect{
+		out.Routers = append(out.Routers, &RouterInspect{
 			PathTemplate:     pathTemplate,
 			PathRegexp:       pathRegexp,
 			QueriesTemplates: queriesTemplates,

--- a/router/mux/mux.go
+++ b/router/mux/mux.go
@@ -43,9 +43,17 @@ type muxRouter struct {
 // Option is mux router option.
 type Option func(*muxRouter)
 
+type preRouterCloner interface {
+	clonePreRouter() PreRouter
+}
+
 // WithPreRouter sets the pre-router for mux router.
 func WithPreRouter(r PreRouter) Option {
 	return func(m *muxRouter) {
+		if cloner, ok := r.(preRouterCloner); ok {
+			m.pre = cloner.clonePreRouter()
+			return
+		}
 		m.pre = r
 	}
 }

--- a/router/mux/prerouter.go
+++ b/router/mux/prerouter.go
@@ -64,6 +64,14 @@ type exactEntry struct {
 const anyMethod = ""
 const anyHost = ""
 
+func (n nopRouter) clonePreRouter() PreRouter {
+	return nopRouter{}
+}
+
+func (e *exactRouter) clonePreRouter() PreRouter {
+	return NewExactRouter()
+}
+
 func (e *exactRouter) Register(route *mux.Route, handler http.Handler) {
 	pathTemplate, err := route.GetPathTemplate()
 	if err != nil || !isExactPathTemplate(pathTemplate) {

--- a/router/mux/prerouter.go
+++ b/router/mux/prerouter.go
@@ -49,7 +49,7 @@ type exactRouter struct {
 
 // NewExactRouter returns an experimental exact pre-router. Use it at your own
 // risk.
-func NewExactRouter() *exactRouter {
+func NewExactRouter() PreRouter {
 	return &exactRouter{
 		handlers: make(map[string][]exactEntry),
 	}

--- a/router/mux/prerouter.go
+++ b/router/mux/prerouter.go
@@ -1,0 +1,167 @@
+package mux
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+)
+
+type PreRouter interface {
+	Register(*mux.Route, http.Handler)
+	Match(*http.Request) (http.Handler, bool)
+	Inspect() json.RawMessage
+}
+
+type nopRouter struct{}
+
+func NewNopRouter() nopRouter                                { return nopRouter{} }
+func (n nopRouter) Register(*mux.Route, http.Handler)        {}
+func (n nopRouter) Match(*http.Request) (http.Handler, bool) { return nil, false }
+func (n nopRouter) Inspect() json.RawMessage                 { return nil }
+
+var _ PreRouter = (*nopRouter)(nil)
+
+// exactRouter is a pre-router for gorilla/mux that resolves exact routes before
+// the request enters mux's ordered route matcher. It is used only for routes
+// that can be matched accurately by method, host, and path.
+// Note: exactRouter is currently experimental. Use it at your own risk.
+//
+// Gorilla mux evaluates routes in registration order and stops at the first
+// route that matches. That is correct for mux's general matcher model, but it
+// means exact gateway routes can still be order-dependent when they share a path
+// and differ only by host or method scope. A hostless route matches requests for
+// every host, and a methodless route matches every method, so either one can
+// shadow a more specific route if it was registered first.
+//
+// exactRouter preserves that mux behavior by grouping exact routes by path and
+// keeping each path bucket in registration order. Matching scans only the bucket
+// for the request path and returns the first entry whose method and host scopes
+// match the request.
+//
+// Routes that are not exact, such as path-prefix, wildcard, template, or regexp
+// routes, should remain handled by gorilla mux because their precedence still
+// depends on mux's full matcher semantics.
+type exactRouter struct {
+	handlers map[string][]exactEntry
+}
+
+// NewExactRouter returns an experimental exact pre-router. Use it at your own
+// risk.
+func NewExactRouter() *exactRouter {
+	return &exactRouter{
+		handlers: make(map[string][]exactEntry),
+	}
+}
+
+type exactEntry struct {
+	method  string
+	host    string
+	handler http.Handler
+}
+
+const anyMethod = ""
+const anyHost = ""
+
+func (e *exactRouter) Register(route *mux.Route, handler http.Handler) {
+	pathTemplate, err := route.GetPathTemplate()
+	if err != nil || !isExactPathTemplate(pathTemplate) {
+		return
+	}
+	pathRegexp, err := route.GetPathRegexp()
+	if err != nil || !strings.HasSuffix(pathRegexp, "$") {
+		return
+	}
+	methods, err := route.GetMethods()
+	if err != nil {
+		methods = []string{anyMethod}
+	}
+	host, err := route.GetHostTemplate()
+	if err != nil {
+		host = anyHost
+	}
+	if !isExactHostTemplate(host) {
+		return
+	}
+	path := cleanPath(pathTemplate)
+	for _, method := range methods {
+		e.handlers[path] = append(e.handlers[path], exactEntry{
+			method:  method,
+			host:    host,
+			handler: handler,
+		})
+	}
+}
+
+func (e *exactRouter) Match(r *http.Request) (http.Handler, bool) {
+	path := r.URL.Path
+	host := getHost(r)
+	for _, entry := range e.handlers[path] {
+		if entry.method != anyMethod && entry.method != r.Method {
+			continue
+		}
+		if entry.host != anyHost && entry.host != host {
+			continue
+		}
+		return entry.handler, true
+	}
+	return nil, false
+}
+
+func (e *exactRouter) Inspect() json.RawMessage {
+	type inspectEntry struct {
+		Method string `json:"method"`
+		Path   string `json:"path"`
+		Host   string `json:"host"`
+	}
+	out := make([]inspectEntry, 0)
+	for path, entries := range e.handlers {
+		for _, entry := range entries {
+			out = append(out, inspectEntry{
+				Method: entry.method,
+				Path:   path,
+				Host:   entry.host,
+			})
+		}
+	}
+	data, _ := json.Marshal(out)
+	return data
+}
+
+var _ PreRouter = (*exactRouter)(nil)
+
+func getHost(r *http.Request) string {
+	if r.URL.IsAbs() {
+		return r.URL.Host
+	}
+	return r.Host
+}
+
+// Exact path templates are the subset that mux will compile to a literal,
+// anchored regexp and that gateway did not register as a prefix route. The
+// relevant mux path is:
+//
+//	Route.Path -> addRegexpMatcher -> newRouteRegexp -> braceIndices
+//
+// In newRouteRegexp, "{name}" and "{name:regexp}" are parsed as variables, and
+// the regexp part may contain "[]()" or other regexp syntax. Those templates
+// cannot be looked up by a raw method/host/path key. Gateway route patterns
+// ending in "*" are registered with Route.PathPrefix instead of Route.Path, so
+// "*" is also excluded for paths.
+func isExactPathTemplate(pattern string) bool {
+	return !strings.ContainsAny(pattern, "*{}[]()")
+}
+
+// Exact host templates follow the same mux parser path as paths:
+//
+//	Route.Host -> addRegexpMatcher -> newRouteRegexp -> braceIndices
+//
+// For hosts, mux treats "{name}" and "{name:regexp}" as variables and uses a
+// host-specific default variable pattern. The custom regexp part can contain
+// "[]()" or other regexp syntax, so those templates cannot be indexed as a raw
+// host string. Unlike paths, hosts do not use gateway's trailing "*" prefix
+// convention here, so "*" is not filtered.
+func isExactHostTemplate(host string) bool {
+	return !strings.ContainsAny(host, "{}[]()")
+}

--- a/router/mux/prerouter.go
+++ b/router/mux/prerouter.go
@@ -64,14 +64,6 @@ type exactEntry struct {
 const anyMethod = ""
 const anyHost = ""
 
-func (n nopRouter) clonePreRouter() PreRouter {
-	return nopRouter{}
-}
-
-func (e *exactRouter) clonePreRouter() PreRouter {
-	return NewExactRouter()
-}
-
 func (e *exactRouter) Register(route *mux.Route, handler http.Handler) {
 	pathTemplate, err := route.GetPathTemplate()
 	if err != nil || !isExactPathTemplate(pathTemplate) {

--- a/router/mux/prerouter_test.go
+++ b/router/mux/prerouter_test.go
@@ -98,7 +98,7 @@ func TestRouteOrder(t *testing.T) {
 				router := NewRouter(
 					testHandler("not-found"),
 					testHandler("method-not-allowed"),
-					WithPreRouter(NewExactRouter()),
+					WithPreRouter(func() PreRouter { return NewExactRouter() }),
 				).(*muxRouter)
 				for _, route := range tc.routes {
 					mustHandle(t, router, path, route.method, route.host, testHandler(route.name))
@@ -175,7 +175,7 @@ func newBenchmarkRouter(b *testing.B, routeCount int, exactRouter bool) *muxRout
 	b.Helper()
 	opts := []Option{}
 	if exactRouter {
-		opts = append(opts, WithPreRouter(NewExactRouter()))
+		opts = append(opts, WithPreRouter(func() PreRouter { return NewExactRouter() }))
 	}
 	router := NewRouter(
 		benchmarkHandler("not-found"),

--- a/router/mux/prerouter_test.go
+++ b/router/mux/prerouter_test.go
@@ -1,0 +1,238 @@
+package mux
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+)
+
+// TestRouteOrder documents gorilla/mux's first-match behavior for exact routes
+// that share the same path but have different method or host scopes, and
+// verifies exactRouter preserves that behavior. Hostless routes match every
+// host, and methodless routes match every method, so registering either one
+// before a more specific route shadows that more specific route. Registering
+// the more specific route first selects it for matching requests.
+func TestRouteOrder(t *testing.T) {
+	const (
+		host = "api.example.com"
+		path = "/api/echo"
+	)
+
+	testCases := []struct {
+		name   string
+		routes []testRoute
+		method string
+		want   string
+	}{
+		{
+			name: "hostless route before host-specific route",
+			routes: []testRoute{
+				{name: "hostless", method: http.MethodGet},
+				{name: "host-specific", method: http.MethodGet, host: host},
+			},
+			method: http.MethodGet,
+			want:   "hostless",
+		},
+		{
+			name: "host-specific route before hostless route",
+			routes: []testRoute{
+				{name: "host-specific", method: http.MethodGet, host: host},
+				{name: "hostless", method: http.MethodGet},
+			},
+			method: http.MethodGet,
+			want:   "host-specific",
+		},
+		{
+			name: "methodless route before method-specific route",
+			routes: []testRoute{
+				{name: "methodless", host: host},
+				{name: "method-specific", method: http.MethodGet, host: host},
+			},
+			method: http.MethodGet,
+			want:   "methodless",
+		},
+		{
+			name: "method-specific route before methodless route",
+			routes: []testRoute{
+				{name: "method-specific", method: http.MethodGet, host: host},
+				{name: "methodless", host: host},
+			},
+			method: http.MethodGet,
+			want:   "method-specific",
+		},
+		{
+			name: "methodless route still handles methods skipped by method-specific route",
+			routes: []testRoute{
+				{name: "method-specific", method: http.MethodGet, host: host},
+				{name: "methodless", host: host},
+			},
+			method: http.MethodPost,
+			want:   "methodless",
+		},
+	}
+
+	t.Run("gorilla mux", func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				router := NewRouter(
+					testHandler("not-found"),
+					testHandler("method-not-allowed"),
+				).(*muxRouter)
+				for _, route := range tc.routes {
+					mustHandle(t, router, path, route.method, route.host, testHandler(route.name))
+				}
+
+				req := httptest.NewRequest(tc.method, path, nil)
+				req.Host = host
+				if got := serveLabel(router, req); got != tc.want {
+					t.Fatalf("handler = %q, want %q", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("exact router", func(t *testing.T) {
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				router := NewRouter(
+					testHandler("not-found"),
+					testHandler("method-not-allowed"),
+					WithPreRouter(NewExactRouter()),
+				).(*muxRouter)
+				for _, route := range tc.routes {
+					mustHandle(t, router, path, route.method, route.host, testHandler(route.name))
+				}
+
+				req := httptest.NewRequest(tc.method, path, nil)
+				req.Host = host
+				if got := serveLabel(router, req); got != tc.want {
+					t.Fatalf("handler = %q, want %q", got, tc.want)
+				}
+			})
+		}
+	})
+}
+
+type testRoute struct {
+	name   string
+	method string
+	host   string
+}
+
+type noopCloser struct{}
+
+func (noopCloser) Close() error { return nil }
+
+func mustHandle(t *testing.T, router *muxRouter, path, method, host string, handler http.Handler) {
+	t.Helper()
+	if err := router.Handle(path, method, host, handler, noopCloser{}); err != nil {
+		t.Fatalf("handle route: %v", err)
+	}
+}
+
+func testHandler(label string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(label))
+	})
+}
+
+func serveLabel(handler http.Handler, req *http.Request) string {
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	return w.Body.String()
+}
+
+func BenchmarkRouteMatch(b *testing.B) {
+	const routeCount = 3000
+
+	testCases := []struct {
+		name        string
+		exactRouter bool
+	}{
+		{name: "gorilla mux"},
+		{name: "exact router", exactRouter: true},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			router := newBenchmarkRouter(b, routeCount, tc.exactRouter)
+			verifyBenchmarkRoutes(b, router, routeCount)
+
+			req := httptest.NewRequest(benchmarkMethod(routeCount-1), benchmarkPath(routeCount-1), nil)
+			w := benchmarkResponseWriter{header: make(http.Header)}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				router.ServeHTTP(&w, req)
+			}
+		})
+	}
+}
+
+func newBenchmarkRouter(b *testing.B, routeCount int, exactRouter bool) *muxRouter {
+	b.Helper()
+	opts := []Option{}
+	if exactRouter {
+		opts = append(opts, WithPreRouter(NewExactRouter()))
+	}
+	router := NewRouter(
+		benchmarkHandler("not-found"),
+		benchmarkHandler("method-not-allowed"),
+		opts...,
+	).(*muxRouter)
+	for i := range routeCount {
+		if err := router.Handle(benchmarkPath(i), benchmarkMethod(i), "", benchmarkHandler(benchmarkFlag(i)), noopCloser{}); err != nil {
+			b.Fatalf("handle route: %v", err)
+		}
+	}
+	return router
+}
+
+func verifyBenchmarkRoutes(b *testing.B, router http.Handler, routeCount int) {
+	b.Helper()
+	for i := range routeCount {
+		w := benchmarkResponseWriter{header: make(http.Header)}
+		req := httptest.NewRequest(benchmarkMethod(i), benchmarkPath(i), nil)
+		router.ServeHTTP(&w, req)
+		if got, want := w.Header().Get(benchmarkRouteHeader), benchmarkFlag(i); got != want {
+			b.Fatalf("route %d header %s = %q, want %q", i, benchmarkRouteHeader, got, want)
+		}
+	}
+}
+
+var benchmarkMethods = []string{
+	http.MethodGet,
+	http.MethodPost,
+	http.MethodPut,
+	http.MethodPatch,
+	http.MethodDelete,
+}
+
+func benchmarkMethod(i int) string {
+	return benchmarkMethods[i%len(benchmarkMethods)]
+}
+
+func benchmarkPath(i int) string {
+	return "/api/route/" + strconv.Itoa(i)
+}
+
+func benchmarkFlag(i int) string {
+	return "route-" + strconv.Itoa(i)
+}
+
+const benchmarkRouteHeader = "X-Benchmark-Route"
+
+func benchmarkHandler(flag string) http.Handler {
+	value := []string{flag}
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header()[benchmarkRouteHeader] = value
+	})
+}
+
+type benchmarkResponseWriter struct{ header http.Header }
+
+func (w *benchmarkResponseWriter) Header() http.Header         { return w.header }
+func (w *benchmarkResponseWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (w *benchmarkResponseWriter) WriteHeader(int)             {}

--- a/router/mux/prerouter_test.go
+++ b/router/mux/prerouter_test.go
@@ -98,7 +98,7 @@ func TestRouteOrder(t *testing.T) {
 				router := NewRouter(
 					testHandler("not-found"),
 					testHandler("method-not-allowed"),
-					WithPreRouter(func() PreRouter { return NewExactRouter() }),
+					WithPreRouter(NewExactRouter()),
 				).(*muxRouter)
 				for _, route := range tc.routes {
 					mustHandle(t, router, path, route.method, route.host, testHandler(route.name))
@@ -175,7 +175,7 @@ func newBenchmarkRouter(b *testing.B, routeCount int, exactRouter bool) *muxRout
 	b.Helper()
 	opts := []Option{}
 	if exactRouter {
-		opts = append(opts, WithPreRouter(func() PreRouter { return NewExactRouter() }))
+		opts = append(opts, WithPreRouter(NewExactRouter()))
 	}
 	router := NewRouter(
 		benchmarkHandler("not-found"),


### PR DESCRIPTION
Add an optional exact pre-router for mux that indexes exact method, host, and path routes before falling back to gorilla/mux.

This PR is based on https://github.com/go-kratos/gateway/pull/261 and keeps its mux fast-path work while preserving gorilla/mux registration-order behavior for hostless and methodless routes.

Note: exactRouter is currently experimental. Use it at your own risk.

Closes #261.

```
# go test ./router/mux -run '^$' -bench BenchmarkRouteMatch -benchmem
goos: darwin
goarch: arm64
pkg: github.com/go-kratos/gateway/router/mux
cpu: Apple M4
BenchmarkRouteMatch/gorilla_mux-10         	   15996	     74620 ns/op	     848 B/op	       7 allocs/op
BenchmarkRouteMatch/exact_router-10        	31432572	        39.04 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/go-kratos/gateway/router/mux	4.138s
```