### PR TITLE
fix: 解决proxy调用Update方法后导致之前存在相同的endpoint的watcher停止且无法重新创建的问题（#263）

### DIFF
--- a/client/factory.go
+++ b/client/factory.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -79,15 +78,13 @@ func NewFactory(r registry.Discovery, opts ...Option) Factory {
 	}
 	return func(builderCtx *BuildContext, endpoint *config.Endpoint) (Client, error) {
 		picker := o.pickerBuilder.Build()
-		ctx, cancel := context.WithCancel(context.Background())
 		applier := &nodeApplier{
-			cancel:       cancel,
 			endpoint:     endpoint,
 			registry:     r,
 			picker:       picker,
 			buildContext: builderCtx,
 		}
-		if err := applier.apply(ctx); err != nil {
+		if err := applier.apply(); err != nil {
 			return nil, err
 		}
 		client := newClient(applier, picker)
@@ -98,13 +95,12 @@ func NewFactory(r registry.Discovery, opts ...Option) Factory {
 type nodeApplier struct {
 	canceled     int64
 	buildContext *BuildContext
-	cancel       context.CancelFunc
 	endpoint     *config.Endpoint
 	registry     registry.Discovery
 	picker       selector.Selector
 }
 
-func (na *nodeApplier) apply(ctx context.Context) error {
+func (na *nodeApplier) apply() error {
 	var nodes []selector.Node
 	for _, backend := range na.endpoint.Backends {
 		target, err := parseTarget(backend.Target)
@@ -118,7 +114,7 @@ func (na *nodeApplier) apply(ctx context.Context) error {
 			nodes = append(nodes, node)
 			na.picker.Apply(nodes)
 		case "discovery":
-			existed := AddWatch(ctx, na.registry, target.Endpoint, na)
+			existed := AddWatch(na.registry, target.Endpoint, na)
 			if existed {
 				log.Infof("watch target %+v already existed", target)
 			}
@@ -168,7 +164,6 @@ func (na *nodeApplier) Callback(services []*registry.ServiceInstance) error {
 func (na *nodeApplier) Cancel() {
 	log.Infof("Closing node applier for endpoint: %+v", na.endpoint)
 	atomic.StoreInt64(&na.canceled, 1)
-	na.cancel()
 }
 
 func (na *nodeApplier) Canceled() bool {

--- a/client/servicewatch.go
+++ b/client/servicewatch.go
@@ -55,6 +55,7 @@ func instancesSetHash(instances []*registry.ServiceInstance) string {
 }
 
 type watcherStatus struct {
+	cancel            context.CancelFunc
 	watcher           registry.Watcher
 	initializedChan   chan struct{}
 	selectedInstances []*registry.ServiceInstance
@@ -109,7 +110,7 @@ type Applier interface {
 	Canceled() bool
 }
 
-func (s *serviceWatcher) Add(ctx context.Context, discovery registry.Discovery, endpoint string, applier Applier) (watcherExisted bool) {
+func (s *serviceWatcher) Add(discovery registry.Discovery, endpoint string, applier Applier) (watcherExisted bool) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -131,12 +132,15 @@ func (s *serviceWatcher) Add(ctx context.Context, discovery registry.Discovery, 
 		ws = &watcherStatus{
 			initializedChan: make(chan struct{}),
 		}
-		watcher, err := discovery.Watch(ctx, endpoint)
+		watcherCtx, watcherCancel := context.WithCancel(context.Background())
+		watcher, err := discovery.Watch(watcherCtx, endpoint)
 		if err != nil {
+			watcherCancel()
 			LOG.Errorf("Failed to initialize watcher on endpoint: %s, err: %+v", endpoint, err)
 			return false
 		}
 		LOG.Infof("Succeeded to initialize watcher on endpoint: %s", endpoint)
+		ws.cancel = watcherCancel
 		ws.watcher = watcher
 		s.watcherStatus[endpoint] = ws
 
@@ -159,9 +163,9 @@ func (s *serviceWatcher) Add(ctx context.Context, discovery registry.Discovery, 
 			var initialResolveCtx context.Context
 			var initialResolveCancel context.CancelFunc
 			if _initialResolveTimeout > 0 {
-				initialResolveCtx, initialResolveCancel = context.WithTimeout(ctx, _initialResolveTimeout)
+				initialResolveCtx, initialResolveCancel = context.WithTimeout(watcherCtx, _initialResolveTimeout)
 			} else {
-				initialResolveCtx, initialResolveCancel = context.WithCancel(ctx)
+				initialResolveCtx, initialResolveCancel = context.WithCancel(watcherCtx)
 			}
 			defer initialResolveCancel()
 
@@ -261,6 +265,14 @@ func (s *serviceWatcher) proccleanup() {
 					delete(appliers, id)
 				}
 				LOG.Infof("Succeeded to clean %d appliers on endpoint: %q, now %d appliers are available", len(cleanup), endpoint, len(appliers))
+				if len(appliers) == 0 {
+					if ws, ok := s.watcherStatus[endpoint]; ok {
+						ws.cancel()
+						delete(s.watcherStatus, endpoint)
+					}
+					delete(s.appliers, endpoint)
+					LOG.Infof("Remove empty appliers and watcherStatus record on endpoint: %q", endpoint)
+				}
 			}()
 		}
 	}
@@ -290,6 +302,6 @@ func (s *serviceWatcher) DebugHandler() http.Handler {
 	return debugMux
 }
 
-func AddWatch(ctx context.Context, registry registry.Discovery, endpoint string, applier Applier) bool {
-	return globalServiceWatcher.Add(ctx, registry, endpoint, applier)
+func AddWatch(registry registry.Discovery, endpoint string, applier Applier) bool {
+	return globalServiceWatcher.Add(registry, endpoint, applier)
 }


### PR DESCRIPTION
解决#263的问题,不是使用单个nodeApplier的cancel来控制water的停止,而是根据serviceWatcher的appliers数量来控制,只有当appliers数量为0才停止watcher